### PR TITLE
Create generic TableCardView component to refactor lore, rules

### DIFF
--- a/src/components/TableCardView.tsx
+++ b/src/components/TableCardView.tsx
@@ -1,0 +1,127 @@
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
+import { ItemCard } from "../components/ItemCard";
+import { SearchBar } from "../components/SearchBar";
+import { useEffect, useState } from "react";
+import { Table } from "../components/Table";
+import { filterTable } from "../helpers/tableHelpers";
+import { TableColumn } from "../helpers/types";
+
+type dataType = {
+  id: number;
+  title: string;
+  detail: string;
+  cards: {
+    id: number;
+    header: string;
+    content: string;
+  }[];
+};
+
+type TableCardViewProps<T extends dataType, K extends keyof T> = {
+  columns: Array<TableColumn<T, K>>;
+  data: Array<T>;
+  route: string;
+  tableClass: string;
+};
+
+// Create headers for each column of the table
+export const TableCardView = <T extends dataType, K extends keyof T>({
+  columns,
+  data,
+  route,
+  tableClass,
+}: TableCardViewProps<T, K>): JSX.Element => {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams({
+    filter: "",
+  });
+  const { dataId } = useParams() || 1;
+  const filterWords = searchParams.get("filter") || "";
+  const [fadeIn, setFadeIn] = useState<boolean>(true);
+
+  // UseEffect to allow fade in of UI elements
+  useEffect(() => {
+    setFadeIn(false);
+    const timeoutId = setTimeout(() => {
+      setFadeIn(true);
+    }, 300);
+
+    return () => clearTimeout(timeoutId);
+  }, [setFadeIn]);
+
+  if (data.length === 0) {
+    return <div>Loading. . .</div>;
+  }
+
+  // Filter the table of rules if there are words to filter
+  const filtereddata = filterWords
+    ? filterTable(data, filterWords.trim().split(" "), columns)
+    : data;
+  // Grab the current rule using the id parameter
+  const dataIndex = data.findIndex((dataItem) => {
+    return dataItem.id == Number(dataId);
+  });
+  const dataItem = data[dataIndex];
+
+  // Handle table filter change
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newFilterWord = event.target.value;
+    setSearchParams(
+      (prev) => {
+        prev.set("filter", newFilterWord);
+        return prev;
+      },
+      { replace: true }
+    );
+  };
+
+  // If a particular row is clicked, it should redirect to the rule url
+  const handleRowClick = (row: T) => {
+    if (Number(dataId) === row.id) {
+      // Don't do anything if they click the same row as the url
+      return;
+    }
+    setFadeIn(false); // Hide the current element
+    setTimeout(() => {
+      setFadeIn(true);
+      navigate(`/${route}/${row.id}`); // change to the clicked url
+    }, 300);
+  };
+
+  const cards = dataItem?.cards.map((card) => {
+    return <ItemCard key={card.id} title={card.header} desc={card.content} />;
+  });
+  return (
+    <>
+      <div className={`${tableClass} table-container`}>
+        <div className="search-container">
+          <SearchBar
+            title="Filter:"
+            value={filterWords}
+            onChange={handleChange}
+            onFocus={() => {}}
+            onBlur={() => {}}
+          />
+        </div>
+        <Table
+          data={filtereddata}
+          columns={columns}
+          rowClick={handleRowClick}
+          selected={Number(dataId)}
+        />
+      </div>
+      <div className={`detail-card fadeElement ${fadeIn ? "fade" : ""}`}>
+        {dataItem ? (
+          <ItemCard title={dataItem.title} desc={dataItem.detail}>
+            {cards}
+          </ItemCard>
+        ) : (
+          <ItemCard
+            title="Loading the Table"
+            desc="Choose an element from the table"
+          />
+        )}
+      </div>
+    </>
+  );
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,10 +6,10 @@ import "./index.scss";
 import ErrorPage from "./routes/ErrorPage";
 import { Index } from "./routes/index";
 import Question from "./routes/Question";
-import Rule from "./routes/Rule";
-import Lore from "./routes/Lore";
+import { Rule } from "./routes/Rule";
 import { Opportunity } from "./routes/Opportunity.js";
 import { Technique } from "./routes/Technique.js";
+import { Lore } from "./routes/Lore.js";
 
 const router = createBrowserRouter([
   {
@@ -26,11 +26,11 @@ const router = createBrowserRouter([
             element: <Question />,
           },
           {
-            path: "lore/:loreId",
+            path: "lore/:dataId",
             element: <Lore />,
           },
           {
-            path: "rules/:ruleId",
+            path: "rules/:dataId",
             element: <Rule />,
           },
           {

--- a/src/routes/Lore.tsx
+++ b/src/routes/Lore.tsx
@@ -1,107 +1,16 @@
-import { useParams, useNavigate, useSearchParams } from "react-router-dom";
-import { ItemCard } from "../components/ItemCard";
+import { TableCardView } from "../components/TableCardView";
 import { useLore, columns } from "../helpers/useLore";
-import { SearchBar } from "../components/SearchBar";
-import { TLore } from "../helpers/types";
-import { useEffect, useState } from "react";
-import { Table } from "../components/Table";
-import { filterTable } from "../helpers/tableHelpers";
 import "./Lore.scss";
 
-export default function Lore() {
-  const lore = useLore();
-  const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams({
-    filter: "",
-  });
-  const { loreId } = useParams() || 1;
-  const filterWords = searchParams.get("filter") || "";
-  const [fadeIn, setFadeIn] = useState<boolean>(true);
+export const Lore = function () {
+  const loreData = useLore();
 
-    // UseEffect to allow fade in of UI elements
-    useEffect(() => {
-      setFadeIn(false);
-      const timeoutId = setTimeout(() => {
-        setFadeIn(true);
-      }, 300);
-  
-      return () => clearTimeout(timeoutId);
-    }, [setFadeIn]);
-  
-    if (lore.length === 0) {
-      return <div>Loading. . .</div>;
-    }
-  
-    // Filter the table of rules if there are words to filter
-    const filteredLore = filterWords
-      ? filterTable(lore, filterWords.trim().split(" "), columns)
-      : lore;
-    // Grab the current rule using the id parameter
-    const loreIndex = lore.findIndex((loreItem) => {
-      return loreItem.id == Number(loreId);
-    });
-    const loreItem = lore[loreIndex];
-  
-    // Handle table filter change
-    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      const newFilterWord = event.target.value;
-      setSearchParams(
-        (prev) => {
-          prev.set("filter", newFilterWord);
-          return prev;
-        },
-        { replace: true }
-      );
-    };
-  
-    // If a particular row is clicked, it should redirect to the rule url
-    const handleRowClick = (row: TLore) => {
-      if (Number(loreId) === row.id) {
-        // Don't do anything if they click the same row as the url
-        return;
-      }
-      setFadeIn(false); // Hide the current element
-      setTimeout(() => {
-        setFadeIn(true);
-        navigate(`/lore/${row.id}`); // change to the clicked url
-      }, 300);
-    };
-  
-    const cards = loreItem?.cards.map((card) => {
-      return <ItemCard key={card.id} title={card.header} desc={card.content} />;
-    });
   return (
-    <>
-      <div className="lore-table table-container">
-        <div className="search-container">
-          <SearchBar
-            title="Filter:"
-            value={filterWords}
-            onChange={handleChange}
-            onFocus={() => {}}
-            onBlur={() => {}}
-          />
-        </div>
-        <Table
-          data={filteredLore}
-          columns={columns}
-          rowClick={handleRowClick}
-          selected={Number(loreId)}
-        />
-      </div>
-      <div className={`detail-card fadeElement ${fadeIn ? "fade" : ""}`}>
-        {loreItem ? (
-          <ItemCard 
-          title={loreItem.title}
-          desc={loreItem.detail}
-          >{cards}</ItemCard>
-        ) : (
-          <ItemCard
-            title="Loading the Table"
-            desc="Choose an element from the table"
-          />
-        )}
-      </div>
-    </>
+    <TableCardView
+      columns={columns}
+      data={loreData}
+      route={"lore"}
+      tableClass={"lore-table"}
+    />
   );
-}
+};

--- a/src/routes/Question.scss
+++ b/src/routes/Question.scss
@@ -34,6 +34,10 @@
   }
 }
 
+.question-card > .desc > .card {
+  border-color: silver;
+}
+
 @media only screen and (min-width: 780px) {
   .question-table {
     width: 700px;
@@ -50,10 +54,14 @@
 @media only screen and (min-width: 1080px) {
   .question-table {
     width: 500px;
+    font-size: 12px;
   }
+
   .question-card {
     max-width: calc(100dvw - 600px);
     margin-top: 0;
     max-height: 80dvh;
+    overflow-y: auto;
+    @include custom-scrollbar;
   }
 }

--- a/src/routes/Rule.tsx
+++ b/src/routes/Rule.tsx
@@ -1,108 +1,16 @@
-import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { ItemCard } from "../components/ItemCard";
-import { useState, useEffect } from "react";
+import { TableCardView } from "../components/TableCardView";
 import { useRules, columns } from "../helpers/useRules";
-import { Table } from "../components/Table";
-import { TRule } from "../helpers/types";
-import { SearchBar } from "../components/SearchBar";
-import { filterTable } from "../helpers/tableHelpers";
 import "./Rule.scss";
 
-export default function Rule() {
-  const rules = useRules();
-  const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams({
-    filter: "",
-  });
-  const { ruleId } = useParams() || 1;
-  const filterWords = searchParams.get("filter") || "";
-  const [fadeIn, setFadeIn] = useState<boolean>(true);
-
-  // UseEffect to allow fade in of UI elements
-  useEffect(() => {
-    setFadeIn(false);
-    const timeoutId = setTimeout(() => {
-      setFadeIn(true);
-    }, 300);
-
-    return () => clearTimeout(timeoutId);
-  }, [setFadeIn]);
-
-  if (rules.length === 0) {
-    return <div>Loading. . .</div>;
-  }
-
-  // Filter the table of rules if there are words to filter
-  const filteredRules = filterWords
-    ? filterTable(rules, filterWords.trim().split(" "), columns)
-    : rules;
-  // Grab the current rule using the id parameter
-  const ruleIndex = rules.findIndex((rule) => {
-    return rule.id == Number(ruleId);
-  });
-  const rule = rules[ruleIndex];
-
-  // Handle table filter change
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newFilterWord = event.target.value;
-    setSearchParams(
-      (prev) => {
-        prev.set("filter", newFilterWord);
-        return prev;
-      },
-      { replace: true }
-    );
-  };
-
-  // If a particular row is clicked, it should redirect to the rule url
-  const handleRowClick = (row: TRule) => {
-    if (Number(ruleId) === row.id) {
-      // Don't do anything if they click the same row as the url
-      return;
-    }
-    setFadeIn(false); // Hide the current element
-    setTimeout(() => {
-      setFadeIn(true);
-      navigate(`/rules/${row.id}`); // change to the clicked url
-    }, 300);
-  };
-
-  const cards = rule?.cards.map((card) => {
-    return <ItemCard key={card.id} title={card.header} desc={card.content} />;
-  });
+export const Rule = function () {
+  const ruleData = useRules();
 
   return (
-    <>
-      <div className="rule-table table-container">
-        <div className="search-container">
-          <SearchBar
-            title="Filter:"
-            value={filterWords}
-            onChange={handleChange}
-            onFocus={() => {}}
-            onBlur={() => {}}
-          />
-        </div>
-        <Table
-          data={filteredRules}
-          columns={columns}
-          rowClick={handleRowClick}
-          selected={Number(ruleId)}
-        />
-      </div>
-      <div className={`detail-card fadeElement ${fadeIn ? "fade" : ""}`}>
-        {rule ? (
-          <ItemCard 
-            title={rule.title}
-            desc={rule.detail}
-            >{cards}</ItemCard>
-        ) : (
-          <ItemCard
-            title="Loading the Table"
-            desc="Choose an element from the table"
-          />
-        )}
-      </div>
-    </>
+    <TableCardView
+      columns={columns}
+      data={ruleData}
+      route={"rules"}
+      tableClass={"rule-table"}
+    />
   );
-}
+};


### PR DESCRIPTION
This refactor adds:
* A reusable table + cardview component such that both lore and rules previously repeated, allowing extension for other views that require a table from a list of data as well as a card to display the data of the selected card. 
* Changes to CSS that are more specific to prevent styles from selecting more than they should
* Reducing the amount of code in routes significantly