### PR TITLE
Strict Key filtering for Tables Added

### DIFF
--- a/src/helpers/tableHelpers.ts
+++ b/src/helpers/tableHelpers.ts
@@ -18,7 +18,7 @@ export const filterTable = <T, K extends keyof T>(
   // For each row
   return arr.filter((row: T) => {
     // Check if all keywords are contained in at least one of the columns
-    return keywords.every((keyword) => {
+    return  keywords.every((keyword) => {
       const lcWord = keyword.toLowerCase();
       return columns.some((column) => {
         const columnValue = row[column.key];
@@ -33,4 +33,9 @@ export const filterTable = <T, K extends keyof T>(
       });
     });
   });
+};
+
+const findStrictKeywords = <T, K extends keyof T>(columns: TableColumn<T, K>[], keywords: string[], keyArray: string[]): string[] => {
+  // 
+  return ['test']
 };

--- a/src/helpers/tableHelpers.ts
+++ b/src/helpers/tableHelpers.ts
@@ -13,13 +13,26 @@ Note: Not case sensitive because it's inconvenient for mobile users
 export const filterTable = <T, K extends keyof T>(
   arr: T[],
   keywords: string[],
-  columns: TableColumn<T, K>[]
+  columns: TableColumn<T, K>[],
+  strictWords?: T[K][] | undefined,
+  strictKey?: K
 ): T[] => {
-  // For each row
+  // Early convert all keywords to lowercase
+  keywords = keywords.map((word) => word.toLowerCase());
+  // Find first strict keyword that matches and transform to match data by capitalizing first letter
+  let strictKeyword = undefined;
+  if (strictWords) {
+    strictKeyword = keywords.find(word => strictWords.includes(word as T[K]))
+    strictKeyword = strictKeyword ? strictKeyword[0].toUpperCase() + strictKeyword.slice(1) : undefined;
+  }
   return arr.filter((row: T) => {
+    // Check if any keywords match scrictKey, remove any rows that do not match strictKeyword
+    if (strictKeyword && strictKey && strictKeyword !== row[strictKey]) {
+      return false;
+    }
     // Check if all keywords are contained in at least one of the columns
-    return  keywords.every((keyword) => {
-      const lcWord = keyword.toLowerCase();
+    return keywords.every((keyword) => {
+      const lcWord = keyword;
       return columns.some((column) => {
         const columnValue = row[column.key];
         // If the column's property is a string, check if it includes the keyword
@@ -33,9 +46,4 @@ export const filterTable = <T, K extends keyof T>(
       });
     });
   });
-};
-
-const findStrictKeywords = <T, K extends keyof T>(columns: TableColumn<T, K>[], keywords: string[], keyArray: string[]): string[] => {
-  // 
-  return ['test']
 };

--- a/src/routes/Opportunity.tsx
+++ b/src/routes/Opportunity.tsx
@@ -27,7 +27,7 @@ export const Opportunity = function () {
       <Table
         data={
           filterWord
-            ? filterTable(opps, filterWord.trim().split(" "), columns)
+            ? filterTable(opps, filterWord.trim().split(" "), columns, ["air", "water", "fire", "earth", "void", "any"], "ring")
             : opps
         }
         columns={columns}

--- a/src/routes/Technique.tsx
+++ b/src/routes/Technique.tsx
@@ -41,7 +41,7 @@ export const Technique = function () {
   // Make a new array if it should be filtered using the filterTable helper
   // This means whether a user filters it or not we will always correctly display the selected element
   const filteredTechniques = filterWords
-    ? filterTable(techniques, filterWords.trim().split(" "), columns)
+    ? filterTable(techniques, filterWords.trim().split(" "), columns, ["kata", "shuji", "kiho", "invocation", "ninjutsu", "ritual", "maho"], "type")
     : techniques;
   // Find the index of the technique that matches the Id in the search param
   const techIndex = techniques.findIndex((tech) => {


### PR DESCRIPTION
Users may now rely on more strict filtering for specific words, such as Ring for opportunity or Type for techniques, filtering out anything extraneous even if it includes similar words in other columns.